### PR TITLE
Scheduler refractor

### DIFF
--- a/OS/OSMutexKernel.h
+++ b/OS/OSMutexKernel.h
@@ -13,8 +13,8 @@
 * @brief The different states that one can get from the mutex
 */
 enum MutexLockState_t{
-  MUTEX_UNLOCKED, 
-  MUTEX_LOCKED
+  MUTEX_UNLOCKED = 0, 
+  MUTEX_LOCKED = 1
 };
 
 /*!
@@ -30,13 +30,7 @@ enum MutexLockReturnStatus{
 */
 class MutexLock{
   public:
-    /*!
-    * @brief Basic initializer for dealing with the mutex stuff.
-    */
-    void init(void){
-      this->thread_list.init_priority_queue(MAX_THREADS);
-    }
-
+    
     /*!
     * @brief Allows us to check the current state of our mutex
     * @returns MutexLockState_t state of the mutex
@@ -67,10 +61,7 @@ class MutexLock{
     void unlock(void);
 
   private: 
-    volatile MutexLockState_t state = MUTEX_UNLOCKED;
-
-    // List of threads that are wating on the mutex.     
-    PriorityQueuePointerHeap thread_list; 
+    volatile uint32_t state = MUTEX_UNLOCKED;
 
 };
 

--- a/OS/OSSignalKernel.h
+++ b/OS/OSSignalKernel.h
@@ -60,10 +60,6 @@ class OSSignal{
     private: 
     // Bits data that we are using to wait with 
     volatile uint32_t bits = 0; 
-
-    // All the threads that are sleeping must be waken up
-    thread_t *thread_signal_arr[MAX_THREADS]; 
-    int current_thread_count = 0; 
 };
 
 #endif 

--- a/OS/OSThreadKernel.cpp
+++ b/OS/OSThreadKernel.cpp
@@ -451,12 +451,17 @@ static inline void check_thread_flags(thread_t *thread){
     break; 
 
   case THREAD_BLOCKED_SIGNAL: 
+    if(thread->signal_bits_compare && *thread->signal_bit)
+      thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_SIGNAL_TIMEOUT: 
+    // If either the thread times out or the signal is set.
+    if(thread->signal_bits_compare && *thread->signal_bit || ((millis() - thread->previous_millis) >= thread->interval))
+      thread->flags = THREAD_RUNNING; 
     break; 
   
-  default:
+  default: 
     break;
   }
 }
@@ -490,7 +495,7 @@ inline void os_get_next_thread() {
     // Casting general pointer as a thread pointer
     thread = (thread_t*)current_node->ptr; 
 
-    // Check
+    // Checking to see what the threads are doing. 
     check_thread_flags(thread); 
 
     // The highest priority thread runs first!

--- a/OS/OSThreadKernel.cpp
+++ b/OS/OSThreadKernel.cpp
@@ -434,33 +434,37 @@ static inline void check_thread_flags(thread_t *thread){
   switch (thread->flags)
   {
   case THREAD_SLEEPING:
+    // If the thread was sleeping, and we are waiting on the thread to complete. 
     if((millis() - thread->previous_millis) >= thread->interval)
       thread->flags = THREAD_RUNNING; // We wake up the thread. 
     break;
   
   case THREAD_BLOCKED_SEMAPHORE: 
+    // If there are entrants available for the semaphore, then we run the thread. 
     if(thread->semaphore_max_count >= *thread->mutex_semaphore)
       thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_SEMAPHORE_TIMEOUT:
+    // If there are entrants available or our timeout has occoured
     if(thread->semaphore_max_count >= *thread->mutex_semaphore || ((millis() - thread->previous_millis) >= thread->interval))
-      thread->flags = THREAD_RUNNING; 
-
-    break; 
+      thread->flags = THREAD_RUNNING;
+    break;
 
   case THREAD_BLOCKED_MUTEX: 
+    // If the mutex has been release, then we grab it for the thread
     if(thread->mutex_semaphore == 0)
       thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_MUTEX_TIMEOUT: 
+    // If the mutex has been released or the timeout has occoured, we take care of the thread. 
     if(thread->mutex_semaphore == 0 || ((millis() - thread->previous_millis) >= thread->interval))
       thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_SIGNAL: 
-    // If a thread is 
+    // If a thread is blocked by a signal and waiting for a particular bit to be set, we run the next thread!
     if(thread->signal_bits_compare && *thread->signal_bit)
       thread->flags = THREAD_RUNNING; 
     break; 

--- a/OS/OSThreadKernel.cpp
+++ b/OS/OSThreadKernel.cpp
@@ -439,24 +439,34 @@ static inline void check_thread_flags(thread_t *thread){
     break;
   
   case THREAD_BLOCKED_SEMAPHORE: 
+    if(thread->semaphore_max_count >= *thread->mutex_semaphore)
+      thread->flags = THREAD_RUNNING; 
     break; 
 
-  case THREAD_BLOCKED_SEMAPHORE_TIMEOUT: 
+  case THREAD_BLOCKED_SEMAPHORE_TIMEOUT:
+    if(thread->semaphore_max_count >= *thread->mutex_semaphore || ((millis() - thread->previous_millis) >= thread->interval))
+      thread->flags = THREAD_RUNNING; 
+
     break; 
 
   case THREAD_BLOCKED_MUTEX: 
+    if(thread->mutex_semaphore == 0)
+      thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_MUTEX_TIMEOUT: 
+    if(thread->mutex_semaphore == 0 || ((millis() - thread->previous_millis) >= thread->interval))
+      thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_SIGNAL: 
+    // If a thread is 
     if(thread->signal_bits_compare && *thread->signal_bit)
       thread->flags = THREAD_RUNNING; 
     break; 
 
   case THREAD_BLOCKED_SIGNAL_TIMEOUT: 
-    // If either the thread times out or the signal is set.
+    // If either the thread times out or the signal is set, we run this as next thread. 
     if(thread->signal_bits_compare && *thread->signal_bit || ((millis() - thread->previous_millis) >= thread->interval))
       thread->flags = THREAD_RUNNING; 
     break; 

--- a/OS/OSThreadKernel.h
+++ b/OS/OSThreadKernel.h
@@ -258,8 +258,12 @@ typedef struct{
   // Bits that we are comparing to. 
   volatile uint32_t signal_bits_compare; 
   // THREAD SIGNAL CODE END // 
-  
 
+  // THREAD MUTEX SEMAPHORE CODE BEGIN // 
+  volatile uint32_t *mutex_semaphore; 
+  volatile uint32_t semaphore_max_count; 
+  // THREAD MUTEX SEMAPHORE CODE END // 
+  
 }thread_t;
 
 /*!

--- a/OS/OSThreadKernel.h
+++ b/OS/OSThreadKernel.h
@@ -112,6 +112,46 @@ static const int DEFAULT_STACK0_SIZE = 10240;
 #else 
 static const int DEFAULT_STACK0_SIZE = EXTERNAL_STACK0_SIZE; 
 #endif 
+
+
+/*!
+* @brief Which threads we want to set signals for
+*/
+typedef enum{
+  THREAD_SIGNAL_0   = 0,
+  THREAD_SIGNAL_1   = 1,
+  THREAD_SIGNAL_2   = 2,
+  THREAD_SIGNAL_3   = 3,
+  THREAD_SIGNAL_4   = 4,
+  THREAD_SIGNAL_5   = 5,
+  THREAD_SIGNAL_6   = 6,
+  THREAD_SIGNAL_7   = 7,
+  THREAD_SIGNAL_8   = 8,
+  THREAD_SIGNAL_9   = 9,
+  THREAD_SIGNAL_10  = 10,
+  THREAD_SIGNAL_11  = 11,
+  THREAD_SIGNAL_12  = 12,
+  THREAD_SIGNAL_13  = 13,
+  THREAD_SIGNAL_14  = 14,
+  THREAD_SIGNAL_15  = 15,
+  THREAD_SIGNAL_16  = 16,
+  THREAD_SIGNAL_17  = 17,
+  THREAD_SIGNAL_18  = 18,
+  THREAD_SIGNAL_19  = 19,
+  THREAD_SIGNAL_20  = 20,
+  THREAD_SIGNAL_21  = 21,
+  THREAD_SIGNAL_22  = 22,
+  THREAD_SIGNAL_23  = 23,
+  THREAD_SIGNAL_24  = 24,
+  THREAD_SIGNAL_25  = 25,
+  THREAD_SIGNAL_26  = 26,
+  THREAD_SIGNAL_27  = 27, 
+  THREAD_SIGNAL_28  = 28,
+  THREAD_SIGNAL_29  = 29,
+  THREAD_SIGNAL_30  = 30,
+  THREAD_SIGNAL_31  = 31
+}thread_signal_t;
+
 /*!
 *   @brief register stack frame saved by interrupt
 *   @note Used so that when we get interrupts, we can revert back the original registers. 
@@ -211,6 +251,14 @@ typedef struct{
   // Next time the thread will run (in milliseconds)
   uint32_t previous_millis; 
   uint32_t interval; 
+
+  // THREAD SIGNAL CODE BEGIN //
+  // Bits that we are waiting on for a signal 
+  volatile uint32_t *signal_bit; 
+  // Bits that we are comparing to. 
+  volatile uint32_t signal_bits_compare; 
+  // THREAD SIGNAL CODE END // 
+  
 
 }thread_t;
 
@@ -440,44 +488,6 @@ extern "C" void unused_isr(void);
 * @brief allows us to sleep the thread for a period of time. 
 */ 
 extern "C" int enter_sleep(int ms);
-
-/*!
-* @brief Which threads we want to set signals for
-*/
-typedef enum{
-  THREAD_SIGNAL_0   = 0,
-  THREAD_SIGNAL_1   = 1,
-  THREAD_SIGNAL_2   = 2,
-  THREAD_SIGNAL_3   = 3,
-  THREAD_SIGNAL_4   = 4,
-  THREAD_SIGNAL_5   = 5,
-  THREAD_SIGNAL_6   = 6,
-  THREAD_SIGNAL_7   = 7,
-  THREAD_SIGNAL_8   = 8,
-  THREAD_SIGNAL_9   = 9,
-  THREAD_SIGNAL_10  = 10,
-  THREAD_SIGNAL_11  = 11,
-  THREAD_SIGNAL_12  = 12,
-  THREAD_SIGNAL_13  = 13,
-  THREAD_SIGNAL_14  = 14,
-  THREAD_SIGNAL_15  = 15,
-  THREAD_SIGNAL_16  = 16,
-  THREAD_SIGNAL_17  = 17,
-  THREAD_SIGNAL_18  = 18,
-  THREAD_SIGNAL_19  = 19,
-  THREAD_SIGNAL_20  = 20,
-  THREAD_SIGNAL_21  = 21,
-  THREAD_SIGNAL_22  = 22,
-  THREAD_SIGNAL_23  = 23,
-  THREAD_SIGNAL_24  = 24,
-  THREAD_SIGNAL_25  = 25,
-  THREAD_SIGNAL_26  = 26,
-  THREAD_SIGNAL_27  = 27, 
-  THREAD_SIGNAL_28  = 28,
-  THREAD_SIGNAL_29  = 29,
-  THREAD_SIGNAL_30  = 30,
-  THREAD_SIGNAL_31  = 31
-}thread_signal_t;
 
 /*!
 * @brief The staus of a thread whose bits we wanna check


### PR DESCRIPTION
Refractors the schedule.  I realized the error of my ways. My intentions when moving the scheduler to sleep threads rather than switch into them and check status were correct, but my execution involving implementation of mutexes and semaphores and signaling were misguided. I wanted to do all of the calculations in actual methods of the mutexes and semaphore objects, but as it turns out, causes my code to no longer have O(n) runtime. It became more unpredictable and caused more crashes. 

In this new code, we have the scheduler manage a little more of the stuff that handles the mutexes, semaphores and signals. This may at times add a little more overhead, especially when the current amount of threads waiting on a mutex are low. It scales a lot better. We have linear O(n) runtime, where n is the amount of threads in the system. 

I have been shown the light and now I can see. 